### PR TITLE
Configure logdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ fairly modern of Ansible is recommended.
 | `camac_docroot` | no | "{{ camac_basedir}}/htdocs" | This dir contains the appication entry point. |
 | `camac_datadir` | no | "/var/lib/camac" | Storage directory for uploads to camac and other data. |
 | `camac_releasedir` | no | "/tmp" | Directory to place the unpacked staging directory "camac" into. |
+| `camac_logdir` | no | "{{ camac_basedir }}/log" | This dir contains application logs. |
 
 ### Camac Configuration
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,13 @@ camac_basedir: "/usr/share/camac"
 # This is not usually below camac_basedir since it needs to be in /var/lib
 camac_datadir: "/var/lib/camac"
 
+#################
+# camac logging #
+#################
+
+# directory to write logfiles to
+camac_logdir: "{{ camac_basedir }}/log"
+
 #############################
 # camac cache configuration #
 #############################

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -90,7 +90,10 @@
   file:
     state: directory
     owner: www-data
-    dest: "{{ camac_libdir }}/config/vendor/mpdf/mpdf/tmp"
+    dest: "{{ item }}"
+  with_items:
+    - "{{ camac_libdir }}/config/vendor/mpdf/mpdf/tmp"
+    - "{{ camac_logdir }}"
 
 - name: configure camac php app
   template:

--- a/templates/application.ini.j2
+++ b/templates/application.ini.j2
@@ -41,6 +41,8 @@ login.redirect = false
 phpSettings.display_startup_errors = 0
 phpSettings.display_errors = 0
 
+resources.log.stream.writerParams.stream = "{{ camac_logdir }}/application.log"
+
 [staging : production]
 [testing : production]
 [development : production]


### PR DESCRIPTION
This configures the zf1 logfile to be at `{{ camac_logdir }}/application.log"` so $CUSTOMER can put the logs where they need to be.