### PR TITLE
Differentiate between master and slave installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ fairly modern of Ansible is recommended.
 | `camac_releasedir` | no | "/tmp" | Directory to place the unpacked staging directory "camac" into. |
 | `camac_logdir` | no | "{{ camac_basedir }}/log" | This dir contains application logs. |
 
+### Camac Environment
+
+| variable | required | default| comments |
+| -------- | -------- | ------- | -------- |
+| `camac_env` | no | "development" | Environment for Camac (may be "development", "testing" or, "production" |
+| `camac_master` | no | True | Define if the current server is a master in the camac master/slave concept |
+
 ### Camac Configuration
 
 | variable | required | default| comments |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,8 @@ camac_unarchive_remote_src: yes
 
 camac_env: "development"
 
+camac_master: True
+
 #######################
 # camac configuration #
 #######################

--- a/tasks/keycloak.yml
+++ b/tasks/keycloak.yml
@@ -132,8 +132,20 @@
     JAVA_HOME: "{{ camac_keycloak_java_home | d() }}"
   when: camac_keycloak_create_admin_user
 
+- name: Check if we need to start and enable keycloak
+  set_fact:
+    camac_keycloak_systemd_state: "started"
+    camac_keycloak_systemd_enabled: True
+  when: camac_master
+
+- name: Check if we need to stop and disable keycloak
+  set_fact:
+    camac_keycloak_systemd_state: "stopped"
+    camac_keycloak_systemd_enabled: False
+  when: not camac_master
+
 - name: enable and start wildfly systemd unit for keycloak
   systemd:
     name: wildfly
-    state: started
-    enabled: True
+    state: "{{ camac_keycloak_systemd_state }}"
+    enabled: "{{ camac_keycloak_systemd_enabled }}"


### PR DESCRIPTION
ATM master installs are compelte with local keycloak client and
slaves do not have their own keycloak setup. More differentiating
for slave things is planned later.