### PR TITLE
Backup keycloak on each ansible playbook run

### DIFF
--- a/tasks/keycloak.yml
+++ b/tasks/keycloak.yml
@@ -171,6 +171,12 @@
   notify:
     - restart wildfly
 
+- name: export keycloak database
+  shell: "{{ camac_keycloak_appdir }}/bin/standalone.sh -Dkeycloak.migration.action=export -Dkeycloak.migration.provider=singleFile -Dkeycloak.migration.file={{ camac_keycloak_datadir }}/keycloak-export-{{ ansible_date_time.iso8601 }}.json -Djboss.http.port=8888 -Djboss.https.port=9999 -Djboss.management.http.port=7777"
+  async: 180
+  poll: 0
+  ignore_errors: yes
+
 - name: Check if we need to start and enable keycloak
   set_fact:
     camac_keycloak_systemd_state: "started"


### PR DESCRIPTION
This dumps the complete keycloak database into a json file on each
ansible run. It does so by starting wildfly on non-default ports
in an async task with the proper args. The keycloak export job gets
started in a fire-and-forget manner and the process terminates later
when the backup has been made. This should work on both master and
slave envionments since the exportruns as it's own process and does
not rely on a running wildfly server to complete the export.

More info on this exporting business is [in the keycloak docs](https://www.keycloak.org/docs/2.5/server_admin/topics/export-import.html).