### PR TITLE
Remove app version from application.ini template

### DIFF
--- a/templates/application.ini.j2
+++ b/templates/application.ini.j2
@@ -2,8 +2,6 @@
 
 [production]
 
-appVersion = "{{ camac_version }}"
-
 upload.path = "{{ camac_php_datadir }}"
 
 baseDomain = {{ camac_base_domain }}


### PR DESCRIPTION
The app version will be handled directly in the code in the future; in
the playbook it's only used only to obtain the right download link.