### PR TITLE
Check requirements.txt for changes before install camac api

### DIFF
--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -9,6 +9,25 @@
     - "{{ camac_python_datadir }}"
     - "{{ camac_python_confdir }}"
 
+- name: Review requirements.txt changes
+  block:
+
+    - command:
+        argv:
+          - diff
+          - "{{ camac_python_docroot }}/requirements.txt"
+          - "{{ camac_releasedir }}/camac/django/requirements.txt"
+      register: requirements_diff
+      failed_when: requirements_diff.rc >= 2
+
+    - debug:
+        msg: "{{ requirements_diff.stdout.split('\n') }}"
+      when: requirements_diff.rc > 0
+
+    - pause:
+        prompt: "Requirements have changed. Please review them carefully! (Ctrl+c c => continue, Ctrl+c a => abort)"
+      when: requirements_diff.rc > 0
+
 - name: copy django directory to python service docroot
   synchronize:
     src: "{{ camac_releasedir }}/camac/django/"


### PR DESCRIPTION
Here's what workflow looks like:
```
TASK [camac : command] ***********************************************************************************************************************************************************************************************************************
changed: [localhost]

TASK [camac : debug] *************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": [
        "2d1", 
        "< new_dep=1.0", 
        "15c14", 
        "< psycopg2-binary==2.7.6.122", 
        "---", 
        "> psycopg2-binary==2.7.6.1", 
        "20c19", 
        "< django-reversion==3.0.4", 
        "---", 
        "> django-reversion==3.0.2"
    ]
}

TASK [camac : pause] *************************************************************************************************************************************************************************************************************************
[camac : pause]
Requirements have changed. Please review them carefully! (Ctrl+c c => continue, Ctrl+c a => abort):
Press 'C' to continue the play or 'A' to abort 
ok: [localhost]
```