### PR TITLE
Fix value of camac_demo_mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -255,7 +255,7 @@ camac_python_uwsgi_port: "8181"
 camac_python_uwsgi_processes: 4
 
 # Whether new users are automatically added to a set of different groups for testing/demo purposes.
-camac_demo_mode: no
+camac_demo_mode: "false"
 
 # Url to the iframe embedded ember form
 camac_portal_uri: "http://caluma.127.0.0.1.nip.io/"

--- a/templates/application.ini.j2
+++ b/templates/application.ini.j2
@@ -47,7 +47,7 @@ keycloak.proxy = {{ camac_auth_proxy }}
 resources.log.stream.writerParams.stream = "{{ camac_php_logdir }}/application.log"
 
 ; "Demo mode" for trainings: give more group memberships to new users
-demoMode = "{{ camac_demo_mode }}"
+demoMode = "{{ camac_demo_mode | d(false) }}"
 
 ; Url to the ember caluma form
 portal.uri = {{ camac_portal_uri }}


### PR DESCRIPTION
Yaml booleans get quoted when they are rendered inside a jinja2 template. If this happens in a ini
file template then the setting will always be true because strings are considered truthy.