### PR TITLE
fix(dms): reduce oidc bearer revalidation time

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -353,7 +353,7 @@ caluma_permission_classes: "caluma.core.permissions.AllowAny"
 caluma_data_source_classes: ""
 
 # Time in seconds before bearer token validity is verified again
-caluma_oidc_bearer_token_revalidation_time: 300
+caluma_oidc_bearer_token_revalidation_time: 5
 
 # Url to the dependent camac instance
 caluma_camac_url: "http://camac-ng.local"


### PR DESCRIPTION
Longer caching causes issues with the document merge service
when roles are switched (incorrect templates being returned)