### PR TITLE
Don't delete existing dms templates

### DIFF
--- a/tasks/document_merge_service.yml
+++ b/tasks/document_merge_service.yml
@@ -62,7 +62,6 @@
   synchronize:
     src: "{{ camac_releasedir }}/camac/document-merge-service/templates/"
     dest: "{{ document_merge_service_media_root }}"
-    delete: yes
   delegate_to: "{{ inventory_hostname }}"
 
 - name: clone pyenv-virtualenv git repository


### PR DESCRIPTION
Currently, custom templates are deleted with every deployment.