### PR TITLE
Remove die-on-term option from uwsgi config

### DIFF
--- a/templates/uwsgi.ini.j2
+++ b/templates/uwsgi.ini.j2
@@ -18,10 +18,6 @@ vacuum = true
 # disable this.
 single-interpreter = true
 
-# By default SIGTERM will brutally reload uWSGI instead of shuting it down. With
-# this option enabled SIGTERM shuts down uWSGI as everybody would expect.
-die-on-term = true
-
 # Let uWSGI crash if it is not able to load the application module.
 need-app = true
 


### PR DESCRIPTION
Die-on-term causes the restart of uwsgi to take 90 seconds, see https://bugs.launchpad.net/devstack/+bug/1724497