### PR TITLE
fix(webdav): remove whitespace from bool variable

### DIFF
--- a/templates/camac_api_env.j2
+++ b/templates/camac_api_env.j2
@@ -53,7 +53,7 @@ ENABLE_HISTORICAL_API={{ camac_caluma_enable_historical_api}}
 
 MANABI_ENABLE={{ manabi_enable }}
 MANABI_DEBUG={{ manabi_debug }}
-LOG_FILE_WRITE_SIZES= {{ log_file_write_size }}
+LOG_FILE_WRITE_SIZES={{ log_file_write_size }}
 {% if manabi_shared_key %}
 MANABI_SHARED_KEY="{{ manabi_shared_key }}"
 {% endif %}


### PR DESCRIPTION
With the whitespace, the `environ` module will interpret the value as `False` even if the word `True` is in it (the actual env variable content is " True", note the leading whitespace)

