### PR TITLE
feat: compile translation messages

### DIFF
--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -152,6 +152,12 @@
     app_path: "{{ camac_python_docroot }}"
     virtualenv: "{{ camac_python_pyenv_virtualenv_path }}"
 
+- name: build compiles translation data
+  community.general.django_manage:
+    command: compilemessages
+    app_path: "{{ camac_python_docroot }}"
+    virtualenv: "{{ camac_python_pyenv_virtualenv_path }}"
+
 - name: load initial camac data
   community.general.django_manage:
     command: camac_load


### PR DESCRIPTION
This step is now required in deployment, as it's not part of the development cycle anymore.

In the Docker containers (K8s, compose), it's part of the container's entrypoint script, but here we need to do it as an explicit step in the deployment