### PR TITLE
fix(dms): ensure correct pyenv version is used in dms tasks

### DIFF
--- a/tasks/document_merge_service.yml
+++ b/tasks/document_merge_service.yml
@@ -108,9 +108,11 @@
 - name: install document-merge-service django app dependencies
   ansible.builtin.shell:
     chdir: "{{ document_merge_service_docroot }}"
-    cmd: "{{ document_merge_service_pyenv_virtualenv_path }}/bin/poetry install --no-dev --extras pgsql"
+    cmd: "{{ document_merge_service_pyenv_virtualenv_path }}/bin/poetry install --only main --extras pgsql"
   become: yes
   become_user: "{{ document_merge_service_user }}"
+  environment:
+    PYENV_VERSION: ""
   notify:
     - restart document merge service
 
@@ -152,6 +154,8 @@
     cmd: "{{ document_merge_service_pyenv_virtualenv_path }}/bin/poetry run python {{ document_merge_service_docroot }}/manage.py migrate"
   become: yes
   become_user: "{{ document_merge_service_user }}"
+  environment:
+    PYENV_VERSION: ""
 
 - name: load initial document-merge-service config
   ansible.builtin.shell:
@@ -159,4 +163,6 @@
     cmd: "{{ document_merge_service_pyenv_virtualenv_path }}/bin/poetry run python {{ document_merge_service_docroot }}/manage.py loaddata {{ camac_releasedir }}/camac/document-merge-service/fixtures/dump.json"
   become: yes
   become_user: "{{ document_merge_service_user }}"
+  environment:
+    PYENV_VERSION: ""
   when: document_merge_service_load_data

--- a/templates/document_merge_service_env.j2
+++ b/templates/document_merge_service_env.j2
@@ -46,3 +46,6 @@ NO_PROXY={{ no_proxy }}
 {% endif %}
 
 LD_LIBRARY_PATH=/opt/openssl/lib/
+
+# force path to point to "our" virtualenv. rest is fairly standard
+PATH=/root/.pyenv/versions/document-merge-service/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
The update of poetry to version 2 in the document-merge-service seems to cause python virtualenvs to be handled differently than before.
The applied changes ensure that the correct python virtualenv is used when running the relevant document-merge-service tasks.