### PR TITLE
fix: properly detect relevant meta tag when patching ember index.html

### DIFF
--- a/templates/patch-ember-camac-ng.sh.j2
+++ b/templates/patch-ember-camac-ng.sh.j2
@@ -6,7 +6,7 @@ PATCHED_CONFIG=$(cat  {{ camac_php_docroot }}/public/ember/index.html \
     | python3 -c "import sys, urllib.parse as up; print(up.quote(sys.stdin.read()));")
 
 sed \
-    "s|^<meta name=\"camac-ng/config/environment\".*|<meta name=\"camac-ng/config/environment\" content=\"$PATCHED_CONFIG\" />|" \
+    "s|<meta name=\"camac-ng/config/environment\".*|<meta name=\"camac-ng/config/environment\" content=\"$PATCHED_CONFIG\" />|" \
     -i {{ camac_php_docroot }}/public/ember/index.html
 
 # replace PORTAL_URL in build output from ember-ebau-core

--- a/templates/patch-ember-portal.sh.j2
+++ b/templates/patch-ember-portal.sh.j2
@@ -9,5 +9,5 @@ PATCHED_CONFIG=$(cat  {{ ember_docroot }}/dist/index.html \
     | python3 -c "import sys, urllib.parse as up; print(up.quote(sys.stdin.read()));")
 
 sed \
-    "s|^<meta name=\"caluma-portal/config/environment\".*|<meta name=\"caluma-portal/config/environment\" content=\"$PATCHED_CONFIG\" />|" \
+    "s|<meta name=\"caluma-portal/config/environment\".*|<meta name=\"caluma-portal/config/environment\" content=\"$PATCHED_CONFIG\" />|" \
     -i {{ ember_docroot }}/dist/index.html


### PR DESCRIPTION
Previous Ember versions (?) would produce index.html without indentation, so we could match the meta tags on line beginning. However newer versions produce properly indented HTML, so we can't use line-start as a matching anchor anymore.